### PR TITLE
hot-fix: resolvendo o problema de build

### DIFF
--- a/src/app/domain/events/components/ck-editor/ck-editor.scss
+++ b/src/app/domain/events/components/ck-editor/ck-editor.scss
@@ -1,5 +1,3 @@
-@use 'ckeditor5/ckeditor5.css';
-
 :root {
   --ck-border-radius: 1rem;
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @use "tailwindcss";
 @use '@angular/material' as mat;
+@use 'ckeditor5/ckeditor5.css';
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Send+Flowers&family=Sniglet:wght@400;800&display=swap');
 
 html {


### PR DESCRIPTION
This pull request updates how the CKEditor styles are imported in the project to ensure consistency and proper style application. The main change is moving the import of CKEditor styles from a component-specific SCSS file to the global `src/styles.scss` file.

**Style management improvements:**

* Moved the `ckeditor5/ckeditor5.css` import from `src/app/domain/events/components/ck-editor/ck-editor.scss` to the global `src/styles.scss` file to centralize CKEditor styling and prevent potential duplication or conflicts. [[1]](diffhunk://#diff-b902a330e06bfba2d0a7b63ef41e8b2b4f289a7fd14eed52f105810788435641L1-L2) [[2]](diffhunk://#diff-23fad3928bf3e71585eb4a6e3b2ff72dae02c3ed5a44d2f0deb1d49f0cb3b1a3R3)