### PR TITLE
feat: adiciona modo de visualização para valores brutos e líquidos no dashboard

### DIFF
--- a/src/app/domain/dashboard/components/donations-type-distribution/donations-type-distribution.ts
+++ b/src/app/domain/dashboard/components/donations-type-distribution/donations-type-distribution.ts
@@ -1,8 +1,8 @@
-import { DonationDistribution } from './../../models/indicator-data';
-import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
-import { ApexNonAxisChartSeries, ApexChart, ApexLegend, ApexDataLabels, ApexPlotOptions, ApexTooltip, ApexResponsive } from 'ng-apexcharts';
-import { GenericChartComponent } from '../generic-chart/generic-chart.component';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ApexChart, ApexDataLabels, ApexLegend, ApexNonAxisChartSeries, ApexPlotOptions, ApexResponsive, ApexTooltip } from 'ng-apexcharts';
 import { THEME_COLORS } from '../../../../shared/constants/theme-colors';
+import { GenericChartComponent } from '../generic-chart/generic-chart.component';
+import { DonationDistribution } from './../../models/indicator-data';
 
 @Component({
   selector: 'app-donations-type-distribution',
@@ -11,6 +11,7 @@ import { THEME_COLORS } from '../../../../shared/constants/theme-colors';
 })
 export class DonationsTypeDistribution implements OnInit, OnChanges {
   @Input() data: DonationDistribution | null = null;
+  @Input() viewMode: 'valueLiquid' | 'value' = 'valueLiquid';
 
   series!: ApexNonAxisChartSeries;
   chart!: ApexChart;
@@ -27,19 +28,27 @@ export class DonationsTypeDistribution implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['data']) {
+    if (changes['data'] || changes['viewMode']) {
       this.updateChartData();
     }
   }
 
   private updateChartData(): void {
     if (this.data) {
-      this.series = [this.data.recurring, this.data.oneTime];
+      const recurringValue = this.viewMode === 'valueLiquid' ? this.data.recurringLiquid : this.data.recurring;
+      const oneTimeValue = this.viewMode === 'valueLiquid' ? this.data.oneTimeLiquid : this.data.oneTime;
+      this.series = [recurringValue, oneTimeValue];
     }
   }
 
   private initializeChart(): void {
-    this.series = this.data ? [this.data.recurring, this.data.oneTime] : [0, 0];
+    const recurringValue = this.data
+      ? (this.viewMode === 'valueLiquid' ? this.data.recurringLiquid : this.data.recurring)
+      : 0;
+    const oneTimeValue = this.data
+      ? (this.viewMode === 'valueLiquid' ? this.data.oneTimeLiquid : this.data.oneTime)
+      : 0;
+    this.series = [recurringValue, oneTimeValue];
 
     this.chart = {
       type: 'donut',

--- a/src/app/domain/dashboard/components/donations/donations.ts
+++ b/src/app/domain/dashboard/components/donations/donations.ts
@@ -1,25 +1,25 @@
-import { DonationData } from '../../models/indicator-data';
 import {
   Component,
   Input,
-  OnInit,
   OnChanges,
+  OnInit,
   SimpleChanges,
 } from '@angular/core';
 import {
   ApexAxisChartSeries,
   ApexChart,
+  ApexDataLabels,
+  ApexGrid,
+  ApexLegend,
+  ApexResponsive,
+  ApexStroke,
+  ApexTooltip,
   ApexXAxis,
   ApexYAxis,
-  ApexStroke,
-  ApexLegend,
-  ApexGrid,
-  ApexTooltip,
-  ApexResponsive,
-  ApexDataLabels,
 } from 'ng-apexcharts';
-import { GenericChartComponent } from '../generic-chart/generic-chart.component';
 import { THEME_COLORS } from '../../../../shared/constants/theme-colors';
+import { DonationData } from '../../models/indicator-data';
+import { GenericChartComponent } from '../generic-chart/generic-chart.component';
 
 @Component({
   selector: 'app-donations',
@@ -28,6 +28,7 @@ import { THEME_COLORS } from '../../../../shared/constants/theme-colors';
 })
 export class Donations implements OnInit, OnChanges {
   @Input() data: DonationData[] = [];
+  @Input() viewMode: 'valueLiquid' | 'value' = 'valueLiquid';
 
   series!: ApexAxisChartSeries;
   chart!: ApexChart;
@@ -46,18 +47,20 @@ export class Donations implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['data']) {
+    if (changes['data'] || changes['viewMode']) {
       this.updateChartData();
     }
-    console.log(this.data);
   }
 
   private updateChartData(): void {
     if (this.data && this.data.length > 0) {
-      const recurringData = this.data.map((d) => d.recurring);
-      const oneTimeData = this.data.map((d) => d.oneTime);
+      const recurringData = this.data.map((d) =>
+        this.viewMode === 'valueLiquid' ? d.recurringLiquid : d.recurring
+      );
+      const oneTimeData = this.data.map((d) =>
+        this.viewMode === 'valueLiquid' ? d.oneTimeLiquid : d.oneTime
+      );
       const categories = this.data.map((d) => this.formatPeriod(d.period));
-      console.log('Categories:', categories);
 
       this.series = [
         {
@@ -170,7 +173,6 @@ export class Donations implements OnInit, OnChanges {
       },
     ];
 
-    // Atualiza os dados se fornecidos
     if (this.data && this.data.length > 0) {
       this.updateChartData();
     }
@@ -197,7 +199,6 @@ export class Donations implements OnInit, OnChanges {
       return `${monthNames[parseInt(month) - 1]} ${year}`;
     } else if (period.length === 10) {
       const [_, month, day] = period.split('-');
-      console.log('Month:', month, 'Day:', day);
       const monthNames = [
         'Jan',
         'Fev',

--- a/src/app/domain/dashboard/containers/dashboard/dashboard.html
+++ b/src/app/domain/dashboard/containers/dashboard/dashboard.html
@@ -1,4 +1,23 @@
 <div class="bg-gray-50 min-h-screen">
+  <div class="flex justify-end items-center pb-4 pt-0">
+    <mat-button-toggle-group
+            name="view"
+            aria-label="Visualização"
+            class="hidden sm:inline-flex view-toggle-group"
+            [value]="viewMode"
+            (change)="onViewModeChange($event.value)"
+            >
+            <mat-button-toggle value="valueLiquid">
+              Valor líquido
+              <mat-icon>percent</mat-icon>
+            </mat-button-toggle>
+            <mat-button-toggle value="value">
+              Valor Bruto
+              <span class="material-symbols-outlined">savings</span>
+            </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   <section class="mb-6">
     <mat-card class="w-full" appearance="outlined">
       <mat-card-content class="p-4">
@@ -10,7 +29,7 @@
           @for (indicator of indicators(); track indicator.title) {
             <app-indicator
               [title]="indicator.title"
-              [value]="indicator.value"
+              [value]="viewMode === 'valueLiquid' ? indicator.valueLiquid : indicator.value"
               [valueType]="indicator.valueType"
               [tooltipText]="indicator.tooltipText">
             </app-indicator>
@@ -27,7 +46,9 @@
           <mat-card-title>Tipo de Doação</mat-card-title>
           <app-period-picker (dateRangeSelected)="onDonationsTypeDistributionDateRangeSelected($event)"></app-period-picker>
         </div>
-        <app-donations-type-distribution [data]="donationDistribution()"/>
+        <app-donations-type-distribution
+          [data]="donationDistribution()"
+          [viewMode]="viewMode"/>
       </mat-card-content>
     </mat-card>
     <mat-card class="w-full" appearance="outlined">
@@ -36,7 +57,7 @@
           <mat-card-title>Doações no período</mat-card-title>
           <app-period-picker #donationsDatePicker [excludePeriods]="['Hoje']" (dateRangeSelected)="onDonationsDateRangeSelected($event)"></app-period-picker>
         </div>
-        <app-donations [data]="donationTimeSeries()"/>
+        <app-donations [data]="donationTimeSeries()" [viewMode]="viewMode"/>
       </mat-card-content>
     </mat-card>
   </section>

--- a/src/app/domain/dashboard/containers/dashboard/dashboard.ts
+++ b/src/app/domain/dashboard/containers/dashboard/dashboard.ts
@@ -1,19 +1,30 @@
-import { Indicator } from '../../components/indicator/indicator';
-import { DonationsTypeDistribution } from '../../components/donations-type-distribution/donations-type-distribution';
-import { PeriodPicker, DateRange } from '../../../../shared/components/period-picker/period-picker';
-import { Component, OnInit, inject, signal, OnDestroy } from '@angular/core';
-import { IndicatorData, DonationData, DonationDistribution } from '../../models/indicator-data';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { Donations } from '../../components/donations/donations';
-import { DashboardService, DonationTimeSeriesData, IndicatorsResponse, DonationTypeDistributionResponse, DonationTimeSeriesResponse } from '../../services/dashboard-service';
 import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 import { Subject } from 'rxjs';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
+import { DateRange, PeriodPicker } from '../../../../shared/components/period-picker/period-picker';
+import { DonationsTypeDistribution } from '../../components/donations-type-distribution/donations-type-distribution';
+import { Donations } from '../../components/donations/donations';
+import { Indicator } from '../../components/indicator/indicator';
+import { DonationTimeSeriesData, DonationTimeSeriesResponse, DonationTypeDistributionResponse, IndicatorsResponse } from '../../models/dashboard';
+import { DonationData, DonationDistribution, IndicatorData } from '../../models/indicator-data';
+import { DashboardService } from '../../services/dashboard-service';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [Indicator, DonationsTypeDistribution, Donations, PeriodPicker, FormsModule, MatCardModule, CommonModule],
+  imports: [Indicator,
+            DonationsTypeDistribution,
+            Donations,
+            PeriodPicker,
+            FormsModule,
+            MatCardModule,
+            MatButtonToggleModule,
+            MatIconModule,
+            CommonModule],
   templateUrl: './dashboard.html',
   styleUrls: ['./dashboard.scss']
 })
@@ -28,6 +39,8 @@ export class Dashboard implements OnInit, OnDestroy {
   private indicatorsDateRangeSubject = new Subject<DateRange>();
   private donationDistributionDateRangeSubject = new Subject<DateRange>();
   private donationTimeSeriesDateRangeSubject = new Subject<DateRange>();
+
+  viewMode: 'valueLiquid' | 'value' = 'valueLiquid';
 
   ngOnInit(): void {
     const today = new Date();
@@ -61,6 +74,15 @@ export class Dashboard implements OnInit, OnDestroy {
     this.donationDistributionDateRangeSubject.next(initialRange);
     this.donationTimeSeriesDateRangeSubject.next(initialRange);
 
+    this.setDefaultViewMode();
+  }
+
+  private setDefaultViewMode() {
+    this.viewMode = 'valueLiquid';
+  }
+
+  onViewModeChange(newViewMode: 'valueLiquid' | 'value') {
+    this.viewMode = newViewMode;
   }
 
   onIndicatorsDateRangeSelected(range: DateRange) {
@@ -87,25 +109,29 @@ export class Dashboard implements OnInit, OnDestroy {
           this.indicators.set([
             {
               title: 'Doações',
-              value: response.data.totalDonations,
+              value: response.data.totalDonation,
+              valueLiquid: response.data.totalDonationLiquid,
               valueType: 'currency',
               tooltipText: 'Valor total arrecadado em doações'
             },
             {
               title: 'Média de valor doado',
-              value: response.data.averageDonationValue,
+              value: response.data.averageDonation,
+              valueLiquid: response.data.averageDonationLiquid,
               valueType: 'currency',
               tooltipText: 'Indica quanto, em média, cada pessoa doa. Por que isso é importante? É possível estimar quantos doadores serão necessários para alcançar a meta de arrecadação'
             },
             {
               title: 'Qtde. de doadores',
               value: response.data.totalDonors,
+              valueLiquid: response.data.totalDonors,
               valueType: 'number',
               tooltipText: 'Número total de pessoas que realizaram doações'
             },
             {
               title: 'Padrinhos ativos',
               value: response.data.activeSponsorships,
+              valueLiquid: response.data.activeSponsorships,
               valueType: 'number',
               tooltipText: 'Número de doadores que possuem doações recorrentes ativas'
             }
@@ -128,8 +154,11 @@ export class Dashboard implements OnInit, OnDestroy {
         next: (response: DonationTypeDistributionResponse) => {
           this.donationDistribution.set({
             oneTime: response.data.oneTimeDonation,
+            oneTimeLiquid: response.data.oneTimeDonationLiquid,
             recurring: response.data.recurringDonation,
-            total: response.data.totalDonations
+            recurringLiquid: response.data.recurringDonationLiquid,
+            total: response.data.totalDonation,
+            totalLiquid: response.data.totalDonationLiquid
           });
         },
         error: (error) => {
@@ -142,8 +171,6 @@ export class Dashboard implements OnInit, OnDestroy {
     const startDate = this.formatDateToString(range.startDate);
     const endDate = this.formatDateToString(range.endDate);
     const groupBy = this.calculateGroupBy(range);
-
-    console.log(startDate, endDate, groupBy);
 
     this.dashboardService
       .getDonationsByPeriod(startDate, endDate, groupBy)
@@ -165,18 +192,32 @@ export class Dashboard implements OnInit, OnDestroy {
 
     data.oneTimeDonations.forEach(item => {
       if (!dataMap.has(item.period)) {
-        dataMap.set(item.period, { period: item.period, oneTime: 0, recurring: 0 });
+        dataMap.set(item.period, {
+          period: item.period,
+          oneTime: 0,
+          oneTimeLiquid: 0,
+          recurring: 0,
+          recurringLiquid: 0
+        });
       }
       const current = dataMap.get(item.period)!;
       current.oneTime += item.value;
+      current.oneTimeLiquid += item.valueLiquid;
     });
 
     data.recurringDonations.forEach(item => {
       if (!dataMap.has(item.period)) {
-        dataMap.set(item.period, { period: item.period, oneTime: 0, recurring: 0 });
+        dataMap.set(item.period, {
+          period: item.period,
+          oneTime: 0,
+          oneTimeLiquid: 0,
+          recurring: 0,
+          recurringLiquid: 0
+        });
       }
       const current = dataMap.get(item.period)!;
       current.recurring += item.value;
+      current.recurringLiquid += item.valueLiquid;
     });
 
     return Array.from(dataMap.values()).sort((a, b) => a.period.localeCompare(b.period));

--- a/src/app/domain/dashboard/models/dashboard.ts
+++ b/src/app/domain/dashboard/models/dashboard.ts
@@ -1,0 +1,54 @@
+export interface TimeSeriesFilters {
+  startDate: string;
+  endDate: string;
+  groupBy?: 'month' | 'day';
+}
+
+export interface StatisticsFilters {
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface IndicatorsData {
+  totalDonation: number;
+  totalDonationLiquid: number;
+  averageDonation: number;
+  averageDonationLiquid: number;
+  totalDonors: number;
+  activeSponsorships: number;
+}
+
+export interface IndicatorsResponse {
+  data: IndicatorsData;
+  date: string;
+}
+
+export interface DonationDistributionData {
+  oneTimeDonation: number;
+  oneTimeDonationLiquid: number;
+  recurringDonation: number;
+  recurringDonationLiquid: number;
+  totalDonation: number;
+  totalDonationLiquid: number;
+}
+
+export interface DonationTypeDistributionResponse {
+  data: DonationDistributionData;
+  date: string;
+}
+
+export interface DonationTimeSeriesItem {
+  period: string;
+  value: number;
+  valueLiquid: number;
+}
+
+export interface DonationTimeSeriesData {
+  oneTimeDonations: DonationTimeSeriesItem[];
+  recurringDonations: DonationTimeSeriesItem[];
+}
+
+export interface DonationTimeSeriesResponse {
+  data: DonationTimeSeriesData;
+  date: string;
+}

--- a/src/app/domain/dashboard/models/indicator-data.ts
+++ b/src/app/domain/dashboard/models/indicator-data.ts
@@ -1,6 +1,7 @@
 export interface IndicatorData {
   title: string;
   value: number;
+  valueLiquid: number;
   valueType: 'number' | 'currency';
   tooltipText?: string;
 }
@@ -8,11 +9,16 @@ export interface IndicatorData {
 export interface DonationData {
   period: string;
   oneTime: number;
+  oneTimeLiquid: number;
   recurring: number;
+  recurringLiquid: number;
 }
 
 export interface DonationDistribution {
   oneTime: number;
+  oneTimeLiquid: number;
   recurring: number;
+  recurringLiquid: number;
   total: number;
+  totalLiquid: number;
 }

--- a/src/app/domain/dashboard/services/dashboard-service.ts
+++ b/src/app/domain/dashboard/services/dashboard-service.ts
@@ -2,55 +2,11 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-
-export interface TimeSeriesFilters {
-  startDate: string;
-  endDate: string;
-  groupBy?: 'month' | 'day';
-}
-
-export interface StatisticsFilters {
-  startDate?: string;
-  endDate?: string;
-}
-
-export interface IndicatorsData {
-  totalDonations: number;
-  averageDonationValue: number;
-  totalDonors: number;
-  activeSponsorships: number;
-}
-
-export interface IndicatorsResponse {
-  data: IndicatorsData;
-  date: string;
-}
-
-export interface DonationTypeDistributionResponse {
-  data: DonationDistributionData;
-  date: string;
-}
-
-export interface DonationTimeSeriesItem {
-  period: string;
-  value: number;
-}
-
-export interface DonationTimeSeriesData {
-  oneTimeDonations: DonationTimeSeriesItem[];
-  recurringDonations: DonationTimeSeriesItem[];
-}
-
-export interface DonationTimeSeriesResponse {
-  data: DonationTimeSeriesData;
-  date: string;
-}
-
-export interface DonationDistributionData {
-  oneTimeDonation: number;
-  recurringDonation: number;
-  totalDonations: number;
-}
+import {
+  DonationTimeSeriesResponse,
+  DonationTypeDistributionResponse,
+  IndicatorsResponse
+} from '../models/dashboard';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/components/data-table/data-table.ts
+++ b/src/app/shared/components/data-table/data-table.ts
@@ -1,26 +1,26 @@
-import { AsyncPipe, NgTemplateOutlet, CommonModule } from '@angular/common';
+import { AsyncPipe, CommonModule, NgTemplateOutlet } from '@angular/common';
 import { Component, EventEmitter, HostListener, inject, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatSort, MatSortModule } from '@angular/material/sort';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import { CalendarFilter } from '../calendar-filter/calendar-filter';
-import { SearchInput } from '../search-input/search-input';
+import { BadgeColorConfig, DataPage, DeleteService, TableColumn } from '../../models/data-table-helpers';
 import { DateRange } from '../../models/date-range';
+import { CalendarFilter } from '../calendar-filter/calendar-filter';
 import { ConfirmDeleteDialog } from '../confirm-delete-dialog/confirm-delete-dialog';
 import { FlowerSpinner } from '../flower-spinner/flower-spinner';
-import { DataPage, DeleteService, TableColumn, BadgeColorConfig } from '../../models/data-table-helpers';
+import { SearchInput } from '../search-input/search-input';
 
 @Component({
   selector: 'app-data-table',


### PR DESCRIPTION
This pull request introduces a new "view mode" toggle for donation statistics on the dashboard, allowing users to switch between displaying "Valor líquido" (net value) and "Valor Bruto" (gross value) across all relevant charts and indicators. The change ensures that both types of values are supported and displayed consistently throughout the dashboard, and refactors the underlying data models and services to support these new fields.

**Dashboard feature enhancements:**

* Added a toggle button group to the dashboard UI (`dashboard.html`) for switching between "valueLiquid" and "value" modes, and updated all relevant components to use the selected mode for displaying donation statistics. [[1]](diffhunk://#diff-ac692a27603e00361eaae561833f98e6d6e6bcd072b7a22d19d018661fa2aa19R2-R20) [[2]](diffhunk://#diff-ac692a27603e00361eaae561833f98e6d6e6bcd072b7a22d19d018661fa2aa19L13-R32) [[3]](diffhunk://#diff-ac692a27603e00361eaae561833f98e6d6e6bcd072b7a22d19d018661fa2aa19L30-R51) [[4]](diffhunk://#diff-ac692a27603e00361eaae561833f98e6d6e6bcd072b7a22d19d018661fa2aa19L39-R60)
* Updated the dashboard container logic to manage the new `viewMode` state and propagate it to child components, including methods to handle view mode changes and set defaults. [[1]](diffhunk://#diff-70f3d2109d5dc257e8dce3afa6bbfbdf24bf6b69ba7d1fd51a34ec81c4f7001eR43-R44) [[2]](diffhunk://#diff-70f3d2109d5dc257e8dce3afa6bbfbdf24bf6b69ba7d1fd51a34ec81c4f7001eR76-R85)

**Component logic updates:**

* Modified `DonationsTypeDistribution` and `Donations` components to accept the new `viewMode` input and to display either net or gross values based on the selected mode. Chart data is now dynamically updated when the mode changes. [[1]](diffhunk://#diff-f7cc88f5517912fbfd8dcd7d86d416c2564dbdc9ab8ac5f8037035693873b0d7R14) [[2]](diffhunk://#diff-f7cc88f5517912fbfd8dcd7d86d416c2564dbdc9ab8ac5f8037035693873b0d7L30-R51) [[3]](diffhunk://#diff-405273d28c38f4ea9d72c2cc25c77f0c9dec6b84aa8e06d805669a0acce951e7R31) [[4]](diffhunk://#diff-405273d28c38f4ea9d72c2cc25c77f0c9dec6b84aa8e06d805669a0acce951e7L49-R62)
* Refactored chart data initialization and update logic in both components to support the new value fields. [[1]](diffhunk://#diff-f7cc88f5517912fbfd8dcd7d86d416c2564dbdc9ab8ac5f8037035693873b0d7L30-R51) [[2]](diffhunk://#diff-405273d28c38f4ea9d72c2cc25c77f0c9dec6b84aa8e06d805669a0acce951e7L49-R62) [[3]](diffhunk://#diff-405273d28c38f4ea9d72c2cc25c77f0c9dec6b84aa8e06d805669a0acce951e7L171)

**Data model and service refactoring:**

* Extended `IndicatorData`, `DonationData`, and `DonationDistribution` interfaces to include both gross and net value fields.
* Updated data mapping in the dashboard container to populate both value types for all donation statistics and time series data. [[1]](diffhunk://#diff-70f3d2109d5dc257e8dce3afa6bbfbdf24bf6b69ba7d1fd51a34ec81c4f7001eL110-R135) [[2]](diffhunk://#diff-70f3d2109d5dc257e8dce3afa6bbfbdf24bf6b69ba7d1fd51a34ec81c4f7001eR159-R163) [[3]](diffhunk://#diff-70f3d2109d5dc257e8dce3afa6bbfbdf24bf6b69ba7d1fd51a34ec81c4f7001eR202-R224)
* Moved dashboard-related API response interfaces to a new `dashboard.ts` model file and refactored service imports accordingly, ensuring consistent usage of new fields. [[1]](diffhunk://#diff-ba523f7dd9a7aa8ebb60e3d5dd1092bcbd15f915d6a17da2b477d388a0de0cc0R1-R54) [[2]](diffhunk://#diff-ed30c0a08841f6a4881301798ec4127ecbe889e910a2b55b507142b6d8ae5d32L5-R9)

These changes collectively provide a more flexible and informative dashboard experience, allowing users to analyze donation statistics by either net or gross value as needed.

closes #65